### PR TITLE
fix elif

### DIFF
--- a/guidance/library/_if.py
+++ b/guidance/library/_if.py
@@ -27,7 +27,8 @@ async def if_(value, *, invert=False, _parser_context=None):
 
         # elif block
         if block_content[i][0] == "elif":
-            if parser.visit(block_content[i][1], variable_stack):
+            elif_arg = await parser.visit(block_content[i][1], variable_stack)
+            if elif_arg.value:
                 return await parser.visit(block_content[i+1], variable_stack)
 
         # else block


### PR DESCRIPTION
elif is broken - it always executes the block regardless of the condition
there were two bugs:
1. it doesn't await the argument, so always returns a coroutine rather than the result
2. it evaluates the argument itself, rather than its value